### PR TITLE
chore(): change rules

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -107,7 +107,7 @@ linters:
 
   NestingDepth:
     enabled: true
-    max_depth: 4
+    max_depth: 3
     ignore_parent_selectors: false
 
   PlaceholderInExtend:
@@ -120,6 +120,7 @@ linters:
 
   PropertySortOrder:
     enabled: true
+    order: smacss
     ignore_unspecified: false
     min_properties: 2
     separate_groups: false
@@ -199,7 +200,7 @@ linters:
 
   StringQuotes:
     enabled: true
-    style: double_quotes # or single_quotes
+    style: single_quotes
 
   TrailingSemicolon:
     enabled: true


### PR DESCRIPTION
Configuración para [CSSComb](https://github.com/csscomb/csscomb.js): https://gist.github.com/gmq/c255863cd7377ef3912b

Si lo dejan en alguna parte se puede configurar así en [atom-css-comb](https://atom.io/packages/atom-css-comb):
<img width="836" alt="screen shot 2016-02-23 at 4 28 51 p m" src="https://cloud.githubusercontent.com/assets/472791/13263921/8ec167c8-da4a-11e5-85a6-feb171087c12.png">

En general CSSComb soluciona los problemas de formato que pide el mono excepto el de espacio entre las reglas (`EmptyLineBetweenBlocks`) que está en la [branch `dev`](https://github.com/csscomb/csscomb.js/pull/450) todavía. De todas maneras la regla ya está en el gist para cuando hagan un release.
