### PR TITLE
fix(): change font rule

### DIFF
--- a/config/scss.yml
+++ b/config/scss.yml
@@ -228,7 +228,7 @@ linters:
 
   VariableForProperty:
     enabled: true
-    properties: [font]
+    properties: [font-family]
 
   VendorPrefix:
     enabled: true


### PR DESCRIPTION
`font` es un shorthand para varias cosas, siento que sería más útil forzar el uso de una variable en `font-family` y dejar `font` libre.
